### PR TITLE
Fix closure compiler renaming for ngOnChanges

### DIFF
--- a/projects/log-monitor/src/lib/log-monitor.component.ts
+++ b/projects/log-monitor/src/lib/log-monitor.component.ts
@@ -33,14 +33,14 @@ export class LogMonitorComponent implements OnChanges, AfterViewInit {
 
   ngOnChanges(changes: SimpleChanges) {
 
-    if (changes.history) {
-      this.history = changes.history.currentValue.map(normalizeLogMessage);
+    if (changes['history']) {
+      this.history = changes['history'].currentValue.map(normalizeLogMessage);
     }
 
-    if (changes.logStream && changes.logStream.currentValue) {
+    if (changes['logStream'] && changes['logStream'].currentValue) {
 
       this.zone.run(() => {
-        const normalizedMsg = normalizeLogMessage(changes.logStream.currentValue);
+        const normalizedMsg = normalizeLogMessage(changes['logStream'].currentValue);
         this.history.push(normalizedMsg);
         setTimeout(() => this.scrollToBottom());
       });


### PR DESCRIPTION
Some people like to use the [Closure Compiler](https://developers.google.com/closure/compiler) for performance reasons. This library currently breaks under that compiler but can be made compatible with this very simple change.

SimpleChanges is defined as 
export interface SimpleChanges { [propName: string]: SimpleChange; }
Closure expects wildcard properties to be accessed with obj['name'] rather than obj.name.
This change will stop closure from incorrectly renaming the simple changes properties.